### PR TITLE
Add a gecko ID to the extension

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,5 +27,10 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
+  },
+  "applications": {
+    "gecko": {
+      "id": "cookiequickmanager@ysard"
+    }
   }
 }


### PR DESCRIPTION
Some browsers (like GNU Icecat) will mark an add-on as corrupt if the manifest.json doesn't contain a gecko ID.

This PR fixes that.

Closes #75 #76