### PR TITLE
Fix Netscape cookie export

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -790,7 +790,7 @@ vAPI.template_JSON = {
 vAPI.template_Netscape = {
     name: 'NETSCAPE',
     template: '{DOMAIN_RAW}\t{ISDOMAIN_RAW}\t{PATH_RAW}\t{ISSECURE_RAW}\t{EXPIRES_RAW}\t{NAME_RAW}\t{CONTENT_RAW}',
-    left_tag: '',
+    left_tag: '# Netscape HTTP Cookie File\n\n',
     right_tag: '',
     separator: '\n',
 };

--- a/src/export.js
+++ b/src/export.js
@@ -292,11 +292,11 @@ function build_domain_dump(cookie) {
         '{EXPIRES}': get_timestamp(false),
         '{EXPIRES_RAW}': get_timestamp(true),
         '{ISSECURE}': get_secure_status(false),
-        '{ISSECURE_RAW}': get_secure_status(true),
+        '{ISSECURE_RAW}': get_secure_status(true).toString().toUpperCase(),
         '{ISHTTPONLY_RAW}': cookie.httpOnly,
         '{SAMESITE_RAW}': cookie.sameSite ? cookie.sameSite : "no_restriction",
         '{ISDOMAIN}': get_domain_status(false),
-        '{ISDOMAIN_RAW}': cookie.hostOnly,
+        '{ISDOMAIN_RAW}': cookie.hostOnly.toString().toUpperCase(),
         '{STORE_RAW}': cookie.storeId,
         '{FPI_RAW}': cookie.firstPartyDomain ? cookie.firstPartyDomain : "", // This attr is absent on old FF
     };

--- a/src/export.js
+++ b/src/export.js
@@ -283,6 +283,8 @@ function build_domain_dump(cookie) {
     // Make a local copy of the template
     var template_temp = cookie_clipboard_template.template;
 
+    var isNetscape = cookie_clipboard_template.name == 'NETSCAPE';
+
     var params = {
         '{HOST_RAW}': vAPI.getHostUrl(cookie),
         '{DOMAIN_RAW}': cookie.domain,
@@ -292,11 +294,11 @@ function build_domain_dump(cookie) {
         '{EXPIRES}': get_timestamp(false),
         '{EXPIRES_RAW}': get_timestamp(true),
         '{ISSECURE}': get_secure_status(false),
-        '{ISSECURE_RAW}': get_secure_status(true).toString().toUpperCase(),
-        '{ISHTTPONLY_RAW}': cookie.httpOnly,
+        '{ISSECURE_RAW}': isNetscape ? get_secure_status(true).toString().toUpperCase() : get_secure_status(true),
+        '{ISHTTPONLY_RAW}': isNetscape ? cookie.httpOnly.toString().toUpperCase() : cookie.httpOnly,
         '{SAMESITE_RAW}': cookie.sameSite ? cookie.sameSite : "no_restriction",
         '{ISDOMAIN}': get_domain_status(false),
-        '{ISDOMAIN_RAW}': cookie.hostOnly.toString().toUpperCase(),
+        '{ISDOMAIN_RAW}': isNetscape ? cookie.hostOnly.toString().toUpperCase() : cookie.hostOnly,
         '{STORE_RAW}': cookie.storeId,
         '{FPI_RAW}': cookie.firstPartyDomain ? cookie.firstPartyDomain : "", // This attr is absent on old FF
     };


### PR DESCRIPTION
Append the "# Netscape HTTP Cookie File" comment to the beginning of Netscape cookie exports, and replace the lowercase boolean values for `ISSECURE_RAW`, `ISHTTPONLY_RAW`, and `ISDOMAIN_RAW` with uppercase string versions. 

This fixes #96 by allowing youtube-dl to parse the file properly.